### PR TITLE
Update list of current implementations

### DIFF
--- a/draft-aaron-acme-profiles.md
+++ b/draft-aaron-acme-profiles.md
@@ -36,7 +36,7 @@ This document defines how an ACME Server may offer a selection of different cert
 
 This note is to be removed before publishing as an RFC.
 
-Let's Encrypt's [Boulder](https://github.com/letsencrypt/boulder) ACME Server software fully implements this draft. Let's Encrypt has not yet configured profiles to be advertised in their [Production](https://acme-v02.api.letsencrypt.org/directory) and [Staging](https://acme-staging-v02.api.letsencrypt.org/directory) environments.  The [Pebble](https://github.com/letsencrypt/pebble) ACME Server testbed also implements this draft.
+This document is implemented by at least two ACME Servers ([Boulder](https://github.com/letsencrypt/boulder/issues/7309) and [Pebble](https://github.com/letsencrypt/pebble/pull/473)), and at least six ACME Clients ([Certbot](https://github.com/certbot/certbot/issues/10194), [Lego](https://github.com/go-acme/lego/pull/2415), [eggsampler/acme](https://github.com/eggsampler/acme/pull/25), [caddy](https://github.com/caddyserver/caddy/commit/2c4295ee48f494bc8dda5fa09b37612d520c8b3b), [certifytheweb](https://docs.certifytheweb.com/blog/acme-profiles-draft/), and [poshacme](https://github.com/rmbolger/Posh-ACME/releases/tag/v4.28.0)). It is [deployed](https://letsencrypt.org/2025/01/09/acme-profiles/) by the Let's Encrypt CA, with [three profiles](https://letsencrypt.org/docs/profiles/) advertised in both their [staging](https://acme-staging-v02.api.letsencrypt.org/directory) and [production](https://acme-v02.api.letsencrypt.org/directory) directories.
 
 --- middle
 


### PR DESCRIPTION
Add links to the implementations in two servers and six clients. Also add links to where it has been deployed and is in active use.