### PR TITLE
Improve example URLs in-line with feedback on ARI draft

### DIFF
--- a/draft-aaron-acme-profiles.md
+++ b/draft-aaron-acme-profiles.md
@@ -65,20 +65,20 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "newNonce": "https://example.com/acme/new-nonce",
-  "newAccount": "https://example.com/acme/new-account",
-  "newOrder": "https://example.com/acme/new-order",
-  "newAuthz": "https://example.com/acme/new-authz",
-  "revokeCert": "https://example.com/acme/revoke-cert",
-  "keyChange": "https://example.com/acme/key-change",
+  "newNonce": "https://acme.example.com/new-nonce",
+  "newAccount": "https://acme.example.com/new-account",
+  "newOrder": "https://acme.example.com/new-order",
+  "newAuthz": "https://acme.example.com/new-authz",
+  "revokeCert": "https://acme.example.com/revoke-cert",
+  "keyChange": "https://acme.example.com/key-change",
   "meta": {
-    "termsOfService": "https://example.com/acme/terms/2021-10-05",
-    "website": "https://www.example.com/",
+    "termsOfService": "https://example.com/acme/terms",
+    "website": "https://example.com/acme/docs",
     "caaIdentities": ["example.com"],
     "externalAccountRequired": false,
     "profiles": {
-      "profile1": "https://example.com/docs/profiles#profile1",
-      "profile2": "https://example.com/docs/profiles#profile2",
+      "profile1": "https://example.com/acme/docs/profiles#profile1",
+      "profile2": "https://example.com/acme/docs/profiles#profile2",
     }
   }
 }
@@ -94,19 +94,19 @@ To select a profile, the client includes the desired profile name in the `profil
 
 ~~~ text
 POST /acme/new-order HTTP/1.1
-Host: example.com
+Host: acme.example.com
 Content-Type: application/jose+json
 
 {
   "protected": base64url({
     "alg": "ES256",
-    "kid": "https://example.com/acme/acct/evOfKhNU60wg",
+    "kid": "https://acme.example.com/acct/evOfKhNU60wg",
     "nonce": "5XJ1L3lEkMG7tR6pA00clA",
-    "url": "https://example.com/acme/new-order"
+    "url": "https://acme.example.com/new-order"
   }),
   "payload": base64url({
-    "profile": "profile1"
     "identifiers": [{"type": "dns", "value": "example.org"}],
+    "profile": "profile1"
   }),
   "signature": "H6ZXtGjTZyUnPeKn...wEA4TklBdh3e454g"
 }
@@ -120,10 +120,10 @@ If the server is advertizing profiles and receives a newOrder request which does
    {
      "status": "valid",
      "expires": "2025-01-01T12:00:00Z",
-     "profile": "profile1",
      "identifiers": [{"type": "dns", "value": "example.org"}],
-     "authorizations": ["https://example.com/acme/authz/PAniVnsZcis"],
-     "finalize": "https://example.com/acme/order/TOlocE8rfgo/finalize",
+     "profile": "profile1",
+     "authorizations": ["https://acme.example.com/authz/PAniVnsZcis"],
+     "finalize": "https://acme.example.com/order/TOlocE8rfgo/finalize",
    }
 ~~~
 


### PR DESCRIPTION
The ARI draft received feedback that it would be better for the URLs used in examples to be "acme.example.com", rather than "example.com/acme". Update this document to follow that same advice.