### PR TITLE
Change category from informational to standards-track

### DIFF
--- a/draft-aaron-acme-profiles.md
+++ b/draft-aaron-acme-profiles.md
@@ -1,7 +1,7 @@
 ---
 title: "Automated Certificate Management Environment (ACME) Profiles Extension"
 abbrev: "ACME Profiles"
-category: info
+category: std
 
 docname: draft-aaron-acme-profiles-latest
 submissiontype: IETF


### PR DESCRIPTION
This was always the intent; I'm just new to this markdown system and didn't realize I'd accidentally cargo-culted the `category: info` from the template.