### PR TITLE
Declare that all profile descriptions must be URLs

### DIFF
--- a/draft-ietf-acme-profiles.md
+++ b/draft-ietf-acme-profiles.md
@@ -56,9 +56,9 @@ This document provides a mechanism for ACME Servers to advertise what certificat
 
 An ACME Server which wishes to allow Clients to select profiles MUST include a new field, `profiles`, in the `meta` field of its Directory object.
 
-`profiles` (optional, object):  A map of profile names to human-readable descriptions of those profiles.
+`profiles` (optional, object):  A map of profile names to URLs.
 
-The contents of these human-readable descriptions are up to the CA; for example, they might be prose descriptions of the properties of the profile, or the might be URLs pointing at a documentation site. ACME Clients SHOULD present these profile names and descriptions to their operator during initial setup and at appropriate times thereafter.
+Each profile name is a short unique identifier of the profile, and each URL points to a human-readable description of that profile. CAs MAY use data URIs to provide an in-line text description if they do not wish to host external documentation pages. ACME Clients SHOULD present these profile names and URLs to their operator during initial setup and at appropriate times thereafter.
 
 ~~~ text
     HTTP/1.1 200 OK


### PR DESCRIPTION
This direction was decided upon during IETF 125; see https://datatracker.ietf.org/meeting/125/materials/minutes-125-acme-202603190600-00#draft-ietf-acme-profiles-01--aaron.

Fixes https://github.com/ietf-wg-acme/draft-acme-profiles/issues/13
Fixes https://github.com/ietf-wg-acme/draft-acme-profiles/issues/14
